### PR TITLE
Fix return type

### DIFF
--- a/zathura-pdf-poppler/attachments.c
+++ b/zathura-pdf-poppler/attachments.c
@@ -57,7 +57,7 @@ zathura_error_t pdf_document_attachment_save(zathura_document_t* document, void*
       continue;
     }
 
-    return poppler_attachment_save(attachment, file, NULL);
+    return poppler_attachment_save(attachment, file, NULL) ? ZATHURA_ERROR_OK : ZATHURA_ERROR_UNKNOWN;
   }
 
   return ZATHURA_ERROR_OK;


### PR DESCRIPTION
> [!CAUTION]
> Breaking changes with `zathura`.

I am currently working on implementing [exporting attachments on `zathura-pdf-mupdf`](https://github.com/pwmt/zathura-pdf-mupdf/issues/93) and noticed that
```C
zathura_error_t pdf_document_attachment_save(zathura_document_t* document, void* data, const char* attachmentname, const char* file)
```
returns a `bool` which doesn't make sense. `zathura` similarly checks for a `bool` in `commands.c`:
```C
...
if (zathura_document_attachment_save(document, file_identifier + strlen("attachment-"), export_path) == false) {
  girara_notify(session, GIRARA_ERROR, _("Couldn't write attachment '%s' to '%s'."), file_identifier, file_name);
} else {
  girara_notify(session, GIRARA_INFO, _("Wrote attachment '%s' to '%s'."), file_identifier, export_path);
}
...
```
The first line needs to be changed to
```C
if (zathura_document_attachment_save(document, file_identifier + strlen("attachment-"), export_path) != ZATHURA_ERROR_OK)
```
otherwise, saving attachments would be broken for `zathura-pdf-poppler`.