### PR TITLE
fix build cloning error and missing dep checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,9 +18,10 @@ desktopdir = join_paths(datadir, 'applications')
 zathura = dependency('zathura', version: '>=2026.01.30', fallback: ['zathura', 'zathura_dependency'])
 girara = dependency('girara-gtk3', fallback: ['girara', 'girara_dependency'])
 glib = dependency('glib-2.0')
+gtk3 = dependency('gtk+-3.0')
 poppler = dependency('poppler-glib', version: '>=21.12')
 
-build_dependencies = [zathura, girara, glib, poppler]
+build_dependencies = [zathura, girara, glib, gtk3, poppler]
 
 if get_option('plugindir') == ''
   if zathura.type_name() == 'pkgconfig'

--- a/subprojects/girara.wrap
+++ b/subprojects/girara.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=girara
-url=https://git.pwmt.org/pwmt/girara.git
+url=https://github.com/pwmt/girara.git
 revision=develop

--- a/subprojects/zathura.wrap
+++ b/subprojects/zathura.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 directory=zathura
-url=https://git.pwmt.org/pwmt/zathura.git
+url=https://github.com/pwmt/zathura.git
 revision=develop


### PR DESCRIPTION
I was encountering build errors 

```zsh
$ meson setup build --prefix $(pwd)/install    
The Meson build system
Version: 1.10.1
Source dir: /home/misal-pav/project/tools/zathura-pdf-poppler
Build dir: /home/misal-pav/project/tools/zathura-pdf-poppler/build
Build type: native build
Project name: zathura-pdf-poppler
Project version: 2026.01.30
C compiler for the host machine: cc (gcc 13.3.0 "cc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0")
C linker for the host machine: cc ld.bfd 2.42
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: YES (/usr/bin/pkg-config) 1.8.1
Found CMake: /usr/bin/cmake (3.28.3)
Run-time dependency zathura found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency zathura
Cloning into 'zathura'...
fatal: unable to access 'https://git.pwmt.org/pwmt/zathura.git/': Could not resolve host: git.pwmt.org
ERROR: Subproject zathura is buildable: NO

meson.build:18:10: ERROR: Git command failed: ['/usr/bin/git', 'clone', 'https://git.pwmt.org/pwmt/zathura.git', 'zathura']
```
not sure if it is pointing to internal git? but this is better for public users who'd like to build the plugin from source.

Then I encountered, gtk was not added as a dependency, saw these errors:
```zsh
~/project/tools/zathura-pdf-poppler/build on  develop! ⌚ 15:09:21
$ ninja
[12/166] Compiling C object libpdf-poppler.so.p/zathura-pdf-poppler_meta.c.o
FAILED: [code=1] libpdf-poppler.so.p/zathura-pdf-poppler_meta.c.o 
cc -Ilibpdf-poppler.so.p -I. -I.. -Isubprojects/zathura -I../subprojects/zathura -Isubprojects/girara -I../subprojects/girara -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/poppler/glib -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/pixman-1 -I/usr/include/poppler -fvisibility=hidden -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -Wpedantic -std=c17 -O0 -g -fPIC -DVERSION_MAJOR=2026 -DVERSION_MINOR=01 -DVERSION_REV=30 -D_DEFAULT_SOURCE -Werror=implicit-function-declaration -Werror=vla -Werror=int-conversion -Werror=maybe-uninitialized -MD -MQ libpdf-poppler.so.p/zathura-pdf-poppler_meta.c.o -MF libpdf-poppler.so.p/zathura-pdf-poppler_meta.c.o.d -o libpdf-poppler.so.p/zathura-pdf-poppler_meta.c.o -c ../zathura-pdf-poppler/meta.c
In file included from ../subprojects/zathura/zathura/plugin-api.h:11,
                 from ../zathura-pdf-poppler/plugin.h:15,
                 from ../zathura-pdf-poppler/meta.c:5:
../subprojects/zathura/zathura/links.h:8:10: fatal error: gtk/gtk.h: No such file or directory
    8 | #include <gtk/gtk.h>
      |          ^~~~~~~~~~~
compilation terminated.
[13/166] Compiling C object libpdf-poppler.so.p/zathura-pdf-poppler_page.c.o
```


this patch fixes the problem and builds well.
```zsh
~/project/tools/zathura-pdf-poppler/build on  develop! ⌚ 15:14:29
$ ninja
[166/166] Linking target subprojects/zathura/zathura-sandbox
```

I'm sorry, I did not create a github issue, bundling both in this PR. 

// update: created ise #8 
